### PR TITLE
Introduce options.resolveBasePathForEveryFile for relative paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ Default: ''
 
 Path to find File in case you chose the MD5 Type of cache-busting.
 
+#### options.resolveBasePathForEveryFile
+Type: `Boolean`  
+Default: `undefined`
+
+If true, will override `options.basePath` and will set the `basePath` for every file based on each individual file's path. Useful when using relative paths. 
+
 ## License
 Copyright (c) 2014 Daniel Furze. 
 

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ module.exports = function (options) {
 		}
 
 		var resolveBasePath = function(filePath) {
-			return path.dirname(path.resolve(filePath))+'/';
+			return path.join(path.dirname(path.resolve(filePath)), '/');
 		};
 
 		if(!options.basePath && !options.resolveBasePathForEveryFile){

--- a/index.js
+++ b/index.js
@@ -22,14 +22,22 @@ module.exports = function (options) {
 			return cb(new PluginError('gulp-cachebust', 'Streaming not supported'));
 		}
 
-		if(!options.basePath){
-			options.basePath = path.dirname(path.resolve(file.path))+'/';
+		var resolveBasePath = function(filePath) {
+			return path.dirname(path.resolve(filePath))+'/';
+		};
+
+		if(!options.basePath && !options.resolveBasePathForEveryFile){
+			options.basePath = resolveBasePath(file.path);
 		}
 
 		tempWrite(file.contents, path.extname(file.path))
 		.then(function (tempFile, err) {
 			if (err) {
 				return cb(new PluginError('gulp-cachebust', err));
+			}
+
+			if (options.resolveBasePathForEveryFile) {
+				options.basePath = resolveBasePath(file.path);
 			}
 
 			fs.stat(tempFile, function (err, stats) {


### PR DESCRIPTION
Possible solution to https://github.com/furzeface/gulp-cache-bust/issues/26. Should be non-breaking and includes documentation update as well. 

Adds `options.resolveBasePathForEveryFile` which overrides `options.basePath` and resolves the `basePath` for every file rather than just for the first one in the pipe. 